### PR TITLE
fix: patch 4 Dependabot security alerts (xmldom, postcss, ip-address)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "electron-vite": "^5.0.0",
         "jsdom": "^29.0.1",
         "lucide-react": "^0.400.0",
-        "postcss": "^8.4.39",
+        "postcss": "^8.5.13",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "recharts": "^3.8.1",
@@ -2849,6 +2849,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@xterm/addon-fit": {
@@ -5922,9 +5932,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7221,20 +7231,10 @@
         "node": ">=10.4.0"
       }
     },
-    "node_modules/plist/node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   },
   "overrides": {
     "dompurify": ">=3.4.0",
-    "@xmldom/xmldom": "^0.8.12",
+    "@xmldom/xmldom": "^0.8.13",
     "lodash": "^4.18.1",
     "brace-expansion": "^1.1.13",
     "@electron/universal": {
@@ -168,7 +168,7 @@
     "electron-vite": "^5.0.0",
     "jsdom": "^29.0.1",
     "lucide-react": "^0.400.0",
-    "postcss": "^8.4.39",
+    "postcss": "^8.5.13",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "recharts": "^3.8.1",


### PR DESCRIPTION
## Summary

Addresses all 4 open Dependabot security alerts by bumping transitive dependency pins and a direct devDependency. Also closes Dependabot PR #72.

| Alert | Package | Severity | Fix |
|---|---|---|---|
| #38 #39 #40 | `@xmldom/xmldom` | **High** (×3) — XML node/comment/doctype injection | `^0.8.12` → `^0.8.13` (overrides) |
| #42 | `postcss` | Medium — XSS via unescaped `</style>` in CSS stringify | `^8.4.39` → `^8.5.13` (devDependencies) |
| — | `ip-address` | Moderate — XSS in Address6 HTML-emitting methods | bumped via `npm audit fix` |

None of these packages are imported directly by app source code:
- `@xmldom/xmldom` is used by `plist` → `electron-builder` (macOS build pipeline only)
- `postcss` is used by Tailwind/Vite (CSS build pipeline only)
- `ip-address` is used by `socks` → `socks-proxy-agent` (deeply transitive, no app surface)

## Test plan

- [x] `npm audit` reports 0 vulnerabilities after changes
- [x] `npm run build` passes cleanly
- [x] `npx vitest run` — 617/617 tests pass
- [x] Closes Dependabot PR #72 (postcss bump)