### PR TITLE
Potential fix for code scanning alert no. 31: Uncontrolled data used in path expression

### DIFF
--- a/go-core/internal/helm/repo.go
+++ b/go-core/internal/helm/repo.go
@@ -425,12 +425,17 @@ func (m *HelmRepoManager) GetValues(repoName, chartName, version string) (string
 	}
 
 	// Check local cache.
-	// isSafeHelmIdentifier already rejected path separators and ".." above, but
-	// filepath.Base each component at construction time so the path sanitizer is
-	// explicit and visible to static analysis (CodeQL go/path-injection).
+	// Build cache path from sanitized components, then enforce that the resolved
+	// path remains inside cacheDir (defense in depth against path traversal).
 	cacheDir := filepath.Join(m.settings.RepositoryCache, "archive")
-	cachePath := filepath.Join(cacheDir, fmt.Sprintf("%s-%s-%s.tgz",
-		filepath.Base(repoName), filepath.Base(chartName), filepath.Base(version)))
+	cacheFile := fmt.Sprintf("%s-%s-%s.tgz",
+		filepath.Base(repoName), filepath.Base(chartName), filepath.Base(version))
+	cachePath := filepath.Clean(filepath.Join(cacheDir, cacheFile))
+	relCachePath, err := filepath.Rel(cacheDir, cachePath)
+	if err != nil || relCachePath == ".." || strings.HasPrefix(relCachePath, ".."+string(os.PathSeparator)) || filepath.IsAbs(relCachePath) {
+		return "", fmt.Errorf("invalid cache path")
+	}
+
 	var chartData []byte
 	if data, err := os.ReadFile(cachePath); err == nil {
 		chartData = data


### PR DESCRIPTION
Potential fix for [https://github.com/codingprotocols/podscape/security/code-scanning/31](https://github.com/codingprotocols/podscape/security/code-scanning/31)

Use a **trusted-base containment check** when constructing `cachePath` in `GetValues`:

1. Keep current identifier validation (good defense).
2. Build the file name from sanitized components.
3. Resolve the candidate path with `filepath.Clean`.
4. Verify the resolved path stays inside `cacheDir` using `filepath.Rel` and reject if it escapes (absolute rel or `..` prefix).
5. Use the validated path for `ReadFile`/`WriteFile`.

This should be done in `go-core/internal/helm/repo.go` in `GetValues` around existing lines 427–435. No behavior change for valid inputs; invalid/path-escaping inputs now fail safely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
