### PR TITLE
Potential fix for code scanning alert no. 31: Uncontrolled data used in path expression

### DIFF
--- a/go-core/internal/helm/repo.go
+++ b/go-core/internal/helm/repo.go
@@ -2,6 +2,8 @@ package helm
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -425,11 +427,12 @@ func (m *HelmRepoManager) GetValues(repoName, chartName, version string) (string
 	}
 
 	// Check local cache.
-	// Build cache path from sanitized components, then enforce that the resolved
-	// path remains inside cacheDir (defense in depth against path traversal).
+	// Build cache path from a deterministic hash of identifiers, then enforce that
+	// the resolved path remains inside cacheDir (defense in depth against path traversal).
 	cacheDir := filepath.Join(m.settings.RepositoryCache, "archive")
-	cacheFile := fmt.Sprintf("%s-%s-%s.tgz",
-		filepath.Base(repoName), filepath.Base(chartName), filepath.Base(version))
+	cacheKey := repoName + "\n" + chartName + "\n" + version
+	sum := sha256.Sum256([]byte(cacheKey))
+	cacheFile := hex.EncodeToString(sum[:]) + ".tgz"
 	cachePath := filepath.Clean(filepath.Join(cacheDir, cacheFile))
 	relCachePath, err := filepath.Rel(cacheDir, cachePath)
 	if err != nil || relCachePath == ".." || strings.HasPrefix(relCachePath, ".."+string(os.PathSeparator)) || filepath.IsAbs(relCachePath) {


### PR DESCRIPTION
Potential fix for [https://github.com/codingprotocols/podscape/security/code-scanning/31](https://github.com/codingprotocols/podscape/security/code-scanning/31)

General fix: ensure untrusted inputs are never used as raw filesystem path components. Convert them into a safe, deterministic filename token (allowlist/encoding), then use that token for cache file paths.

Best single fix here (without changing functionality): in `go-core/internal/helm/repo.go` inside `GetValues`, replace the cache filename construction that currently embeds `repoName/chartName/version` directly with a deterministic hash of those values (e.g., SHA-256). This preserves cache semantics (same input triple -> same cache file), avoids path traversal entirely, and satisfies static analysis because the path component becomes a fixed-format hex digest.

Changes needed:
- Add imports: `crypto/sha256` and `encoding/hex`.
- In `GetValues` around cache path construction (current lines ~430–433), compute digest from `repoName + "\n" + chartName + "\n" + version` and use `<hex>.tgz` as filename.
- Keep existing `filepath.Rel` defense-in-depth block unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
