### PR TITLE
ci: bump Homebrew cask on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,3 +185,132 @@ jobs:
             dist/*.deb \
             dist/latest-linux.yml \
             --clobber
+
+  # ── Homebrew cask ────────────────────────────────────────────────────────────
+  # Without this the cask silently keeps pointing at the previous release: the
+  # old dmgs still exist and still match their checksums, so nothing errors and
+  # new `brew install --cask podscape` users just quietly get a stale version.
+  #
+  # Opens a PR rather than pushing to the tap's main, so the tap's own CI
+  # (audit + install + notarization checks) gates the change before users see
+  # it. Requires HOMEBREW_TAP_TOKEN: a token with contents:write and
+  # pull-requests:write on codingprotocols/homebrew-tap. GITHUB_TOKEN cannot be
+  # used for that — it is scoped to this repository only.
+  #
+  # Deliberately does NOT touch Formula/podscape-mcp.rb: that formula still
+  # references podscape-mcp-linux-arm64, which this workflow no longer builds,
+  # so bumping its version would point Linux/arm64 users at a 404.
+  tap:
+    name: Bump Homebrew Cask
+    runs-on: ubuntu-latest
+    needs: [release-mac]
+
+    steps:
+      - name: Checkout tap
+        uses: actions/checkout@v4
+        with:
+          repository: codingprotocols/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Collect dmg checksums
+        id: sums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+          # GitHub publishes a sha256 digest per release asset, so the dmgs
+          # (~270 MB combined) do not need downloading. Fall back to computing
+          # it if a digest is missing — older assets predate the field.
+          sum_for() {
+            local name="$1" digest
+            digest=$(gh api "repos/${REPO}/releases/tags/${GITHUB_REF_NAME}" \
+              --jq ".assets[] | select(.name == \"${name}\") | .digest // empty")
+            if [ -n "$digest" ]; then
+              echo "${digest#sha256:}"
+              return
+            fi
+            echo "::warning::No digest for ${name}; downloading to compute it" >&2
+            gh release download "${GITHUB_REF_NAME}" --repo "${REPO}" \
+              --pattern "${name}" --dir /tmp --clobber >&2
+            shasum -a 256 "/tmp/${name}" | awk '{print $1}'
+          }
+
+          ARM=$(sum_for "Podscape-${VERSION}-arm64.dmg")
+          INTEL=$(sum_for "Podscape-${VERSION}.dmg")
+
+          for pair in "arm:$ARM" "intel:$INTEL"; do
+            printf '%s' "${pair#*:}" | grep -qE '^[0-9a-f]{64}$' || {
+              echo "::error::Could not resolve a sha256 for ${pair%%:*} (got '${pair#*:}')"
+              exit 1
+            }
+          done
+
+          echo "SHA_ARM=$ARM"     >> $GITHUB_ENV
+          echo "SHA_INTEL=$INTEL" >> $GITHUB_ENV
+          echo "arm=$ARM  intel=$INTEL"
+
+      - name: Update cask version and checksums
+        run: |
+          python3 - <<'PYEOF'
+          import os, re, sys
+
+          cask    = "Casks/podscape.rb"
+          version = os.environ["VERSION"]
+          sha_arm = os.environ["SHA_ARM"]
+          sha_int = os.environ["SHA_INTEL"]
+
+          for label, value in (("arm", sha_arm), ("intel", sha_int)):
+              if not re.fullmatch(r"[0-9a-f]{64}", value):
+                  sys.exit(f"refusing to write a malformed {label} sha256: {value!r}")
+
+          src = open(cask).read()
+          # Anchored, and each must match exactly once, so a restructured cask
+          # fails loudly instead of being silently skipped. The sha256 patterns
+          # require 64 hex chars so the `arch arm:/intel:` line is never touched.
+          src, n_v = re.subn(r'^  version "[^"]*"$', f'  version "{version}"', src, flags=re.M)
+          src, n_a = re.subn(r'(sha256 arm:\s+")[0-9a-f]{64}(")', rf'\g<1>{sha_arm}\g<2>', src)
+          src, n_i = re.subn(r'(intel:\s+")[0-9a-f]{64}(")',      rf'\g<1>{sha_int}\g<2>', src)
+          if (n_v, n_a, n_i) != (1, 1, 1):
+              sys.exit(f"expected 1 version/arm/intel stanza, replaced {n_v}/{n_a}/{n_i}")
+
+          open(cask, "w").write(src)
+          print(f"podscape -> {version}")
+          PYEOF
+
+          git diff --stat
+          git diff --quiet && {
+            echo "::notice::Cask already at ${VERSION}; nothing to do."
+            echo "CHANGED=false" >> $GITHUB_ENV
+            exit 0
+          }
+          echo "CHANGED=true" >> $GITHUB_ENV
+
+      - name: Open pull request against the tap
+        if: env.CHANGED == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          BRANCH="podscape-${VERSION}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git commit -aqm "podscape ${VERSION}"
+          git push -f origin "$BRANCH"
+
+          if [ -n "$(gh pr list --repo codingprotocols/homebrew-tap --head "$BRANCH" --json number --jq '.[].number')" ]; then
+            echo "::notice::PR for $BRANCH already open; branch updated."
+            exit 0
+          fi
+
+          gh pr create \
+            --repo codingprotocols/homebrew-tap \
+            --base main --head "$BRANCH" \
+            --title "podscape ${VERSION}" \
+            --body "Automated bump from [Podscape ${GITHUB_REF_NAME}](https://github.com/codingprotocols/podscape/releases/tag/${GITHUB_REF_NAME}).
+
+          Checksums come from GitHub's published digests for the release assets.
+
+          Tap CI will audit and install the cask before this merges."


### PR DESCRIPTION
Tagging a release publishes the dmgs but leaves `Casks/podscape.rb` in [homebrew-tap](https://github.com/codingprotocols/homebrew-tap) untouched. The failure is silent: the previous dmgs still exist and still match their checksums, so nothing errors — new `brew install --cask podscape` users just quietly get the old version.

The tap's README claims these files are "rendered from templates in the podscape repository (`packaging/homebrew/`) and pushed here automatically by its release workflow on every `v*` tag." **That automation does not exist.** Verified against a full clone with all branches and history:

- `packaging/` has never existed — `git log --all -- 'packaging/*'` is empty
- no `.rb`, cask, or homebrew-named file has ever been added, across all refs
- no reference to `homebrew-tap`, `Casks/`, or `brew tap` anywhere in the tree
- every `GH_TOKEN` in `release.yml` is `secrets.GITHUB_TOKEN`, which cannot write to another repo
- the tap's two commits touching `Casks/podscape.rb` are both hand-authored

The cask being at the current version isn't evidence to the contrary: v4.0.4 shipped 2026-07-03 and the tap was seeded by hand on 2026-08-09, so no release has occurred since the tap existed.

This adds the job that makes the claim true. It's the same shape as the one in [Pint](https://github.com/codingprotocols/Pint/blob/main/.github/workflows/release.yml), which has now run for real on v1.4.4.

## Design

**Checksums come from GitHub's per-asset digests**, so the ~270 MB of dmgs are never downloaded and no checksum has to be threaded out of `release-mac`. Falls back to downloading and hashing if a digest is absent.

**Opens a PR** rather than pushing to the tap's `main`, so the tap's audit + install + notarization CI gates the change before users see it.

**Does not touch `Formula/podscape-mcp.rb`** — see below.

## Verified before pushing

Ran the digest logic against the real v4.0.4 release: it reproduces `d1826f7a…c0d8` (arm) and `e213d95c…9a2b` (intel), byte-identical to the checksums already committed in the cask. So a real release would produce a correct bump.

Rewrite logic tested against the actual cask file:

| case | behaviour |
|---|---|
| normal bump | changes only `version` and the two `sha256` values |
| malformed checksum | refuses, exits non-zero |
| missing release asset | rejected, not silently written as empty |
| cask restructured so a stanza stops matching | fails loudly (`replaced 1/1/0`), file untouched |
| already at this version | logs a notice, no empty PR |

The `sha256` patterns require 64 hex characters, so line 2's `arch arm: "-arm64", intel: ""` is never touched — confirmed by diffing the rewritten file. Result still passes `ruby -c`, and `brew style` reports the same 2 pre-existing offenses as the unmodified file, none introduced.

## Requires a secret

`HOMEBREW_TAP_TOKEN` — a token with `contents:write` and `pull-requests:write` on `homebrew-tap`. **It is not currently set on this repo**, so this job will fail on the next release until it's added. Pint has the equivalent secret and its job succeeded on the first real run.

## Separate bug found: the formula points at a binary you no longer build

`Formula/podscape-mcp.rb` references `podscape-mcp-linux-arm64`, but `release.yml` builds only `darwin-arm64`, `darwin-amd64`, `windows-amd64` and `linux-amd64`. v4.0.4 happens to have that asset from an earlier build, so it works today.

The moment the formula's version is bumped to a release built by the current workflow, Linux/arm64 users get a 404. That's why this job deliberately leaves the formula alone — automating it would convert a dormant bug into an automatic one. Either add a `GOOS=linux GOARCH=arm64` build to the Linux job, or drop the `on_arm` block from the formula; happy to do either.