### PR TITLE
fix: pass sidecar token via env, not argv

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,7 +74,7 @@ The sidecar is a standalone HTTP server compiled as `podscape-core`. It is the s
 
 **No-kubeconfig mode**: if no valid kubeconfig is found at startup, the sidecar still starts the HTTP server and sets `NoKubeconfig = true`. `/health` returns 200 immediately so the renderer can show the `KubeConfigOnboarding` screen instead of an error dialog. After the user sets a kubeconfig path, the sidecar is restarted via `window.sidecar.restart()` IPC.
 
-**Token auth**: the sidecar is launched with a randomly generated `--token` flag. Every request (except `/health`) must include the `X-Podscape-Token` header matching that token. The token is passed to the renderer via IPC and injected by `checkedSidecarFetch`.
+**Token auth**: the sidecar is launched with a randomly generated token, passed via the `PODSCAPE_TOKEN` environment variable (not a flag — process arguments are world-readable via `ps`). Every request (except `/health`) must include the `X-Podscape-Token` header matching that token. The token is passed to the renderer via IPC and injected by `checkedSidecarFetch`.
 
 **RBAC probe**: at startup and on every context switch, `rbac.CheckAccess` fires concurrent `SelfSubjectAccessReview` requests for all 28 tracked resource types checking both `list` and `watch` verbs. Results are stored in `ContextCache.AllowedResources map[string]bool`:
 
@@ -251,7 +251,7 @@ flowchart TB
 
 ### Sidecar token auth
 
-At startup, `sidecar/auth.ts` generates a random 64-character hex token (`crypto.randomBytes(32)`). It is passed to the sidecar as the `--token` flag and injected into every HTTP request by `checkedSidecarFetch` as the `X-Podscape-Token` header. The sidecar rejects any request (except `/health`) that omits or mismatches the token. The token is never written to disk and is unique per app session.
+At startup, `sidecar/auth.ts` generates a random 64-character hex token (`crypto.randomBytes(32)`). It is passed to the sidecar in the `PODSCAPE_TOKEN` environment variable, which the sidecar unsets immediately after reading so nothing it spawns inherits it, and injected into every HTTP request by `checkedSidecarFetch` as the `X-Podscape-Token` header. The sidecar rejects any request (except `/health`) that omits or mismatches the token. The token is never written to disk and is unique per app session.
 
 ### Secret masking
 

--- a/go-core/cmd/podscape-core/main.go
+++ b/go-core/cmd/podscape-core/main.go
@@ -52,8 +52,22 @@ func main() {
 		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 	}
 	port := flag.String("port", "5050", "port to listen on")
-	token := flag.String("token", "", "shared secret; requests without X-Podscape-Token matching this value are rejected")
+	// Deprecated in favour of the PODSCAPE_TOKEN environment variable: process
+	// arguments are world-readable (`ps aux`), so a token passed this way can be
+	// read by any local user and replayed against this sidecar.
+	tokenFlag := flag.String("token", "", "DEPRECATED, use PODSCAPE_TOKEN: shared secret; requests without a matching X-Podscape-Token are rejected")
 	flag.Parse()
+
+	authToken := os.Getenv("PODSCAPE_TOKEN")
+	// Do not leak the secret into anything this process spawns (kubectl, helm…).
+	os.Unsetenv("PODSCAPE_TOKEN") //nolint:errcheck
+	if authToken == "" && *tokenFlag != "" {
+		authToken = *tokenFlag
+		log.Printf("[sidecar] -token is deprecated and readable by any local user via `ps`; pass PODSCAPE_TOKEN instead")
+	}
+	if authToken == "" {
+		log.Printf("[sidecar] WARNING: no token supplied — the API is UNAUTHENTICATED and any local process can drive it")
+	}
 
 	// Now that flags are parsed, turn off klog's direct-stderr path and redirect
 	// through a filter that drops bookmark noise. Errors still pass through.
@@ -161,8 +175,8 @@ func main() {
 	// A wildcard CORS header would allow any webpage the user visits to send
 	// requests to the sidecar, defeating the token-auth layer.
 	var handler http.Handler = http.DefaultServeMux
-	if *token != "" {
-		tok := *token
+	if authToken != "" {
+		tok := authToken
 		inner := handler
 		handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// /health is exempt — sidecar.ts polls it without an auth header

--- a/src/main/sidecar/auth.ts
+++ b/src/main/sidecar/auth.ts
@@ -2,7 +2,9 @@ import { randomBytes } from 'crypto'
 
 /**
  * A per-session secret shared between Electron and the Go sidecar.
- * Passed as the -token flag at sidecar startup; included as X-Podscape-Token
- * on every HTTP request so the sidecar can reject calls from other processes.
+ * Passed via the PODSCAPE_TOKEN environment variable at sidecar startup —
+ * never as a command-line flag, since process arguments are world-readable
+ * (`ps aux`). Included as X-Podscape-Token on every HTTP request so the
+ * sidecar can reject calls from other processes.
  */
 export const sidecarToken: string = randomBytes(32).toString('hex')

--- a/src/main/sidecar/sidecar.ts
+++ b/src/main/sidecar/sidecar.ts
@@ -71,9 +71,13 @@ export async function startSidecar(): Promise<void> {
     console.log(`[Sidecar] Port ${SIDECAR_PORT} in use — using port ${port}`)
   }
 
-  const child = spawn(binaryPath, ['-port', String(port), '-kubeconfig', kubeconfigPath, '-token', sidecarToken], {
+  // The token goes through the environment, not argv: process arguments are
+  // world-readable (`ps aux`), so passing it as -token let any local user read
+  // the secret and drive this sidecar. The sidecar unsets the variable after
+  // reading it so nothing it spawns inherits the value.
+  const child = spawn(binaryPath, ['-port', String(port), '-kubeconfig', kubeconfigPath], {
     stdio: is.dev ? 'inherit' : 'pipe',
-    env: getAugmentedEnv(),
+    env: getAugmentedEnv({ PODSCAPE_TOKEN: sidecarToken }),
     windowsHide: true,
     cwd: is.dev ? join(app.getAppPath(), 'go-core') : join(process.resourcesPath, 'bin')
   })


### PR DESCRIPTION
The sidecar's auth token was passed as a command-line flag:

```ts
spawn(binaryPath, ['-port', String(port), '-kubeconfig', kubeconfigPath, '-token', sidecarToken], …)
```

Process arguments are world-readable on macOS and Linux, so **any local user — or any unsandboxed process running as any user — could read the token with `ps aux`** and then drive the sidecar with full authority: read any file under `$HOME` via `/cp/to`, exec into pods, port-forward, and act against the cluster with the user's kubeconfig.

`auth.ts` described the token as existing "so the sidecar can reject calls from other processes", which is precisely what argv exposure defeated.

## What is unchanged

The rest of the design is sound and I've left it alone. Binding to `127.0.0.1`, a per-session `randomBytes(32)` token, and the deliberate omission of CORS headers together defeat the browser-based attack: a page cannot set `X-Podscape-Token` cross-origin without a preflight, and with no CORS headers the preflight fails. Requests that *can* be sent cross-origin arrive without the token and get a 401. That comment in `main.go` explaining why CORS is omitted is correct and worth keeping.

This PR only closes the local-user read.

## Changes

- Token now travels in the `PODSCAPE_TOKEN` environment variable via `getAugmentedEnv({ … })`, which already supports extras
- The sidecar **unsets the variable immediately after reading it**, so nothing it spawns (kubectl, helm, exec) inherits the secret
- `-token` still works as a deprecated fallback, logging a warning that names the exposure — so an older Electron build against a newer sidecar keeps working
- Running with no token at all now logs an explicit `UNAUTHENTICATED` warning. Previously `if *token != ""` silently disabled auth entirely, so a manual launch or a future caller that forgot the flag got a wide-open API with no signal
- `docs/architecture.md` (two places) and the `auth.ts` comment updated — they documented the flag

## Verified against a running sidecar

Built with `go vet` and `go build` clean, then exercised live:

| case | result |
|---|---|
| `/health`, no token (exempt for startup polling) | 200 |
| protected route, no token | 401 |
| protected route, wrong token | 401 |
| protected route, correct token **from env** | 200 |
| deprecated `-token` flag | 200, with deprecation warning logged |
| no token supplied | open, with `UNAUTHENTICATED` warning logged |

And the point of the change:

```
$ ps -o args= -p <pid>
/tmp/podscape-core -port 5599 -kubeconfig /nonexistent
```

No token in the process arguments.

## Note on severity

On a single-user laptop this is minor — an attacker already running as you has your kubeconfig regardless. It matters on shared or multi-user machines, and it makes the token a real boundary against other local processes rather than a nominal one.